### PR TITLE
Allow HUD interactions through overlay

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -114,11 +114,16 @@ canvas {
   justify-content: center;
   backdrop-filter: blur(2px);
   transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .overlay.hidden {
   opacity: 0;
   pointer-events: none;
+}
+
+.overlay .card {
+  pointer-events: auto;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- prevent the full-screen overlay from swallowing HUD clicks while keeping the intro card interactive

## Testing
- Manual verification via Playwright script (Insert $1 & Spawn)


------
https://chatgpt.com/codex/tasks/task_e_68d87dcf12208326a92203536a373f6c