### PR TITLE
Add cash out hold mechanic and bot attacks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,13 +27,14 @@
         <h1>Skill Gamble Arena</h1>
         <p>
           Drop $1 to spawn and battle rival mercenaries for the cash pot. Survive the
-          arena and cash out your winnings. For this prototype, you're matched against
-          static bots &mdash; land your shots to win!
+          arena and cash out your winnings. For this prototype, expect turret-like bots
+          that fire bursts every few seconds &mdash; stay mobile and land your shots to win!
         </p>
         <ul>
           <li>Move with <strong>WASD</strong>, <strong>arrow keys</strong>, or hold <strong>right mouse</strong> to stride.</li>
           <li>Aim with your mouse cursor.</li>
           <li>Left click to fire neon pulses.</li>
+          <li>Hold <strong>G</strong> for three seconds to cash out, but taking damage interrupts the extraction.</li>
         </ul>
         <p class="hint">Press the button above to insert $1 and enter the arena.</p>
       </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -114,11 +114,16 @@ canvas {
   justify-content: center;
   backdrop-filter: blur(2px);
   transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .overlay.hidden {
   opacity: 0;
   pointer-events: none;
+}
+
+.overlay .card {
+  pointer-events: auto;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- add a cash-out hold mechanic with damage-driven cooldowns and victory/defeat handling
- enable arena bots to fire on the player and render their projectiles and effects
- expand HUD and onboarding copy to describe the new cash-out controls and turret behavior

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d87dcf12208326a92203536a373f6c