### PR TITLE
Prevent bot bullet update crash after player defeat

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -11,8 +11,12 @@ const overlayHint = overlay.querySelector('.hint');
 const ENTRY_COST = 1;
 const BOT_COUNT = 3;
 const BOT_CONTRIBUTION = ENTRY_COST;
+const BOT_SHOOT_INTERVAL = 5000;
+const BOT_BULLET_DAMAGE = 20;
+const CASH_OUT_HOLD_DURATION = 3000;
+const CASH_OUT_COOLDOWN = 2000;
 const INTRO_MESSAGE =
-  "Drop $1 to spawn and battle rival mercenaries for the arena pot. Static bots keep the field busy for this prototype—land your neon shots to win!";
+  "Drop $1 to spawn and battle rival mercenaries for the arena pot. Automated turrets keep the field busy for this prototype—land your neon shots, dodge return fire, and escape with the cash!";
 
 const state = {
   wallet: 10,
@@ -25,9 +29,26 @@ const state = {
   keys: new Set(),
 };
 
+const world = {
+  width: 2400,
+  height: 1600,
+  barrierThickness: 120,
+};
+
+const CAMERA_SMOOTHING = 0.12;
+const camera = {
+  x: 0,
+  y: 0,
+};
+
+const BARRIER_DAMAGE_PER_SECOND = 25;
+let barrierDamageBuffer = 0;
+
+let currentTimestamp = 0;
+
 const player = {
-  x: canvas.width / 2,
-  y: canvas.height - 120,
+  x: world.width / 2,
+  y: world.height - world.barrierThickness - 200,
   radius: 18,
   speed: 2.8,
   health: 100,
@@ -37,7 +58,25 @@ const player = {
 
 const bots = [];
 const bullets = [];
+const botBullets = [];
 const particles = [];
+
+const cashOutState = {
+  holding: false,
+  holdStart: 0,
+  cooldownUntil: 0,
+};
+
+function getMouseWorldPosition() {
+  return {
+    x: camera.x + state.mouse.x,
+    y: camera.y + state.mouse.y,
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
 
 class Bot {
   constructor(x, y, tint) {
@@ -48,6 +87,7 @@ class Bot {
     this.health = 60;
     this.maxHealth = 60;
     this.tint = tint;
+    this.lastShot = performance.now();
   }
 
   draw() {
@@ -79,6 +119,34 @@ class Bullet {
     ctx.beginPath();
     ctx.moveTo(this.x, this.y);
     ctx.lineTo(this.x - this.vx * 2, this.y - this.vy * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+class BotBullet {
+  constructor(x, y, angle) {
+    const speed = 4.5;
+    this.x = x;
+    this.y = y;
+    this.vx = Math.cos(angle) * speed;
+    this.vy = Math.sin(angle) * speed;
+    this.life = 160;
+  }
+
+  update(delta = 1) {
+    this.x += this.vx * delta;
+    this.y += this.vy * delta;
+    this.life -= delta;
+  }
+
+  draw() {
+    ctx.save();
+    ctx.strokeStyle = '#ffb347';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(this.x, this.y);
+    ctx.lineTo(this.x - this.vx * 3, this.y - this.vy * 3);
     ctx.stroke();
     ctx.restore();
   }
@@ -120,9 +188,9 @@ function spawnBots() {
   bots.length = 0;
   const colors = ['#ff3cac', '#ffb74d', '#9575cd'];
   const positions = [
-    { x: canvas.width * 0.2, y: canvas.height * 0.32 },
-    { x: canvas.width * 0.5 - 22, y: canvas.height * 0.2 },
-    { x: canvas.width * 0.76, y: canvas.height * 0.38 },
+    { x: world.width * 0.28, y: world.barrierThickness + 260 },
+    { x: world.width * 0.5 - 22, y: world.height * 0.36 },
+    { x: world.width * 0.72, y: world.barrierThickness + 520 },
   ];
   for (let i = 0; i < BOT_COUNT; i += 1) {
     const spot = positions[i % positions.length];
@@ -131,11 +199,18 @@ function spawnBots() {
 }
 
 function resetGame() {
-  player.x = canvas.width / 2;
-  player.y = canvas.height - 120;
+  player.x = world.width / 2;
+  player.y = world.height - world.barrierThickness - 200;
   player.health = player.maxHealth;
   bullets.length = 0;
+  botBullets.length = 0;
   particles.length = 0;
+  cashOutState.holding = false;
+  cashOutState.holdStart = 0;
+  cashOutState.cooldownUntil = performance.now();
+  barrierDamageBuffer = 0;
+  camera.x = clamp(player.x - canvas.width / 2, 0, Math.max(world.width - canvas.width, 0));
+  camera.y = clamp(player.y - canvas.height / 2, 0, Math.max(world.height - canvas.height, 0));
   spawnBots();
 }
 
@@ -150,6 +225,9 @@ function insertAndSpawn() {
   shooting = false;
   mouseDrive = false;
   state.lastShot = 0;
+  cashOutState.holding = false;
+  cashOutState.holdStart = 0;
+  cashOutState.cooldownUntil = performance.now();
   resetGame();
 }
 
@@ -198,7 +276,8 @@ function shoot() {
   const now = performance.now();
   if (now - state.lastShot < state.shootInterval) return;
   state.lastShot = now;
-  const angle = Math.atan2(state.mouse.y - player.y, state.mouse.x - player.x);
+  const mouseWorld = getMouseWorldPosition();
+  const angle = Math.atan2(mouseWorld.y - player.y, mouseWorld.x - player.x);
   const muzzleX = player.x + Math.cos(angle) * (player.radius + 6);
   const muzzleY = player.y + Math.sin(angle) * (player.radius + 6);
   bullets.push(new Bullet(muzzleX, muzzleY, angle));
@@ -207,7 +286,122 @@ function shoot() {
   }
 }
 
-function handleMovement(delta) {
+function completeCashOut() {
+  state.active = false;
+  state.gameOver = true;
+  shooting = false;
+  mouseDrive = false;
+  const winnings = state.pot;
+  state.wallet += winnings;
+  state.pot = 0;
+  updateHUD();
+  cashOutState.holding = false;
+  botBullets.length = 0;
+  barrierDamageBuffer = 0;
+  showOverlay('Cash Out Complete', `You extracted $${winnings.toFixed(2)} from the arena.`);
+}
+
+function interruptCashOut(now) {
+  if (cashOutState.holding) {
+    cashOutState.holding = false;
+    cashOutState.holdStart = 0;
+  }
+  cashOutState.cooldownUntil = Math.max(cashOutState.cooldownUntil, now + CASH_OUT_COOLDOWN);
+}
+
+function updateCashOut(timestamp) {
+  if (!state.active) {
+    cashOutState.holding = false;
+    return;
+  }
+
+  const now = timestamp;
+  if (cashOutState.holding) {
+    if (!state.keys.has('g')) {
+      cashOutState.holding = false;
+      cashOutState.holdStart = 0;
+    } else if (now - cashOutState.holdStart >= CASH_OUT_HOLD_DURATION) {
+      completeCashOut();
+    }
+    return;
+  }
+
+  if (!state.keys.has('g')) return;
+  if (now < cashOutState.cooldownUntil) return;
+
+  cashOutState.holding = true;
+  cashOutState.holdStart = now;
+}
+
+function handlePlayerDefeat() {
+  state.active = false;
+  state.gameOver = true;
+  shooting = false;
+  mouseDrive = false;
+  const loss = state.pot;
+  state.pot = 0;
+  updateHUD();
+  botBullets.length = 0;
+  barrierDamageBuffer = 0;
+  showOverlay('Defeat', loss > 0 ? `You were eliminated and lost the $${loss.toFixed(2)} pot.` : 'You were eliminated.');
+}
+
+function handlePlayerHit(damage, timestamp) {
+  if (!state.active) return;
+  player.health = Math.max(player.health - damage, 0);
+  interruptCashOut(timestamp);
+  for (let i = 0; i < 6; i += 1) {
+    particles.push(new Particle(player.x, player.y, '#ff3cac'));
+  }
+  if (player.health <= 0) {
+    handlePlayerDefeat();
+  }
+}
+
+function handleBotShooting(timestamp) {
+  bots.forEach((bot) => {
+    if (timestamp - bot.lastShot < BOT_SHOOT_INTERVAL) return;
+    bot.lastShot = timestamp;
+    const centerX = bot.x + bot.width / 2;
+    const centerY = bot.y + bot.height / 2;
+    const angle = Math.atan2(player.y - centerY, player.x - centerX);
+    botBullets.push(new BotBullet(centerX, centerY, angle));
+  });
+}
+
+function applyPlayerConstraints(candidateX, candidateY, delta, timestamp) {
+  const innerLeft = world.barrierThickness + player.radius;
+  const innerRight = world.width - world.barrierThickness - player.radius;
+  const innerTop = world.barrierThickness + player.radius;
+  const innerBottom = world.height - world.barrierThickness - player.radius;
+
+  let clampedX = clamp(candidateX, innerLeft, innerRight);
+  let clampedY = clamp(candidateY, innerTop, innerBottom);
+  const touchedBarrier = clampedX !== candidateX || clampedY !== candidateY;
+
+  player.x = clampedX;
+  player.y = clampedY;
+
+  if (touchedBarrier) {
+    applyBarrierDamage(delta, timestamp);
+  }
+}
+
+function applyBarrierDamage(delta, timestamp) {
+  if (!state.active) return;
+  const seconds = delta / 60;
+  barrierDamageBuffer += BARRIER_DAMAGE_PER_SECOND * seconds;
+  if (barrierDamageBuffer >= 1) {
+    const damage = Math.floor(barrierDamageBuffer);
+    barrierDamageBuffer -= damage;
+    handlePlayerHit(damage, timestamp);
+    for (let i = 0; i < 3; i += 1) {
+      particles.push(new Particle(player.x, player.y, '#ff8e53'));
+    }
+  }
+}
+
+function handleMovement(delta, timestamp) {
   const { keys } = state;
   let vx = 0;
   let vy = 0;
@@ -216,26 +410,37 @@ function handleMovement(delta) {
   if (keys.has('a') || keys.has('arrowleft')) vx -= 1;
   if (keys.has('d') || keys.has('arrowright')) vx += 1;
 
-  if (vx !== 0 || vy !== 0) {
-    const length = Math.hypot(vx, vy);
-    vx = (vx / length) * player.speed * delta;
-    vy = (vy / length) * player.speed * delta;
-    player.x = Math.min(Math.max(player.radius, player.x + vx), canvas.width - player.radius);
-    player.y = Math.min(Math.max(player.radius, player.y + vy), canvas.height - player.radius);
-  }
+  if (vx === 0 && vy === 0) return;
+
+  const length = Math.hypot(vx, vy);
+  vx = (vx / length) * player.speed * delta;
+  vy = (vy / length) * player.speed * delta;
+  const candidateX = player.x + vx;
+  const candidateY = player.y + vy;
+  applyPlayerConstraints(candidateX, candidateY, delta, timestamp);
 }
 
-function handleMouseStride(delta) {
+function handleMouseStride(delta, timestamp) {
   if (!mouseDrive) return;
-  const dx = state.mouse.x - player.x;
-  const dy = state.mouse.y - player.y;
+  const mouseWorld = getMouseWorldPosition();
+  const dx = mouseWorld.x - player.x;
+  const dy = mouseWorld.y - player.y;
   const distance = Math.hypot(dx, dy);
   if (distance < 1) return;
   const step = Math.min(player.speed * delta, distance);
   const nx = dx / distance;
   const ny = dy / distance;
-  player.x = Math.min(Math.max(player.radius, player.x + nx * step), canvas.width - player.radius);
-  player.y = Math.min(Math.max(player.radius, player.y + ny * step), canvas.height - player.radius);
+  const candidateX = player.x + nx * step;
+  const candidateY = player.y + ny * step;
+  applyPlayerConstraints(candidateX, candidateY, delta, timestamp);
+}
+
+function updateCamera(delta) {
+  const targetX = clamp(player.x - canvas.width / 2, 0, Math.max(world.width - canvas.width, 0));
+  const targetY = clamp(player.y - canvas.height / 2, 0, Math.max(world.height - canvas.height, 0));
+  const smoothing = 1 - Math.pow(1 - CAMERA_SMOOTHING, Math.max(delta, 0));
+  camera.x += (targetX - camera.x) * smoothing;
+  camera.y += (targetY - camera.y) * smoothing;
 }
 
 function updateBullets(delta) {
@@ -268,6 +473,36 @@ function updateBullets(delta) {
   }
 }
 
+function updateBotBullets(delta, timestamp) {
+  for (let i = botBullets.length - 1; i >= 0; i -= 1) {
+    const bullet = botBullets[i];
+    if (!bullet) {
+      botBullets.splice(i, 1);
+      continue;
+    }
+    bullet.update(delta);
+    if (
+      bullet.life <= 0 ||
+      bullet.x < -20 ||
+      bullet.x > world.width + 20 ||
+      bullet.y < -20 ||
+      bullet.y > world.height + 20
+    ) {
+      botBullets.splice(i, 1);
+      continue;
+    }
+
+    const distance = Math.hypot(bullet.x - player.x, bullet.y - player.y);
+    if (distance <= player.radius) {
+      botBullets.splice(i, 1);
+      handlePlayerHit(BOT_BULLET_DAMAGE, timestamp);
+      if (!state.active) {
+        return;
+      }
+    }
+  }
+}
+
 function updateParticles(delta) {
   for (let i = particles.length - 1; i >= 0; i -= 1) {
     const particle = particles[i];
@@ -283,15 +518,19 @@ function drawBackground() {
   ctx.fillStyle = '#0c0617';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-  ctx.strokeStyle = 'rgba(255, 60, 172, 0.15)';
+  const gridSpacing = 96;
+  const offsetX = -(camera.x % gridSpacing);
+  const offsetY = -(camera.y % gridSpacing);
+
+  ctx.strokeStyle = 'rgba(255, 60, 172, 0.12)';
   ctx.lineWidth = 1;
-  for (let x = 0; x < canvas.width; x += 48) {
+  for (let x = offsetX; x < canvas.width; x += gridSpacing) {
     ctx.beginPath();
     ctx.moveTo(x, 0);
     ctx.lineTo(x, canvas.height);
     ctx.stroke();
   }
-  for (let y = 0; y < canvas.height; y += 48) {
+  for (let y = offsetY; y < canvas.height; y += gridSpacing) {
     ctx.beginPath();
     ctx.moveTo(0, y);
     ctx.lineTo(canvas.width, y);
@@ -301,8 +540,43 @@ function drawBackground() {
   ctx.restore();
 }
 
+function drawBarrier() {
+  const { barrierThickness } = world;
+  const edges = [
+    { x: 0, y: 0, width: world.width, height: barrierThickness, orientation: 'horizontal' },
+    { x: 0, y: world.height - barrierThickness, width: world.width, height: barrierThickness, orientation: 'horizontal' },
+    { x: 0, y: 0, width: barrierThickness, height: world.height, orientation: 'vertical' },
+    { x: world.width - barrierThickness, y: 0, width: barrierThickness, height: world.height, orientation: 'vertical' },
+  ];
+
+  edges.forEach((edge) => {
+    const gradient =
+      edge.orientation === 'horizontal'
+        ? ctx.createLinearGradient(edge.x, edge.y, edge.x, edge.y + edge.height)
+        : ctx.createLinearGradient(edge.x, edge.y, edge.x + edge.width, edge.y);
+    gradient.addColorStop(0, 'rgba(255, 118, 20, 0.85)');
+    gradient.addColorStop(0.5, 'rgba(255, 45, 104, 0.9)');
+    gradient.addColorStop(1, 'rgba(255, 199, 0, 0.8)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(edge.x, edge.y, edge.width, edge.height);
+
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.16)';
+    const step = 18;
+    if (edge.orientation === 'horizontal') {
+      for (let i = 0; i < edge.width; i += step) {
+        ctx.fillRect(edge.x + i, edge.y + (i % (step * 2)), 6, 6);
+      }
+    } else {
+      for (let i = 0; i < edge.height; i += step) {
+        ctx.fillRect(edge.x + (i % (step * 2)), edge.y + i, 6, 6);
+      }
+    }
+  });
+}
+
 function drawPlayer() {
-  const angle = Math.atan2(state.mouse.y - player.y, state.mouse.x - player.x);
+  const mouseWorld = getMouseWorldPosition();
+  const angle = Math.atan2(mouseWorld.y - player.y, mouseWorld.x - player.x);
 
   ctx.save();
   ctx.translate(player.x, player.y);
@@ -378,6 +652,107 @@ function drawUI() {
   ctx.font = '12px "Press Start 2P"';
   ctx.fillText(`POT: $${state.pot.toFixed(2)}`, 150, canvas.height - 36);
   ctx.fillText(`HP: ${Math.max(player.health, 0)}`, 150, canvas.height - 20);
+
+  if (state.active) {
+    ctx.fillStyle = '#f5ff5c';
+    ctx.font = '10px "Press Start 2P"';
+    ctx.fillText('CASH OUT [G]', 40, canvas.height - 4);
+
+    const cooldownRemaining = Math.max(0, cashOutState.cooldownUntil - currentTimestamp);
+    const barX = 150;
+    const barY = canvas.height - 14;
+    const barWidth = 104;
+    const barHeight = 6;
+    ctx.fillStyle = 'rgba(12, 6, 23, 0.7)';
+    ctx.fillRect(barX, barY, barWidth, barHeight);
+
+    let progress = 0;
+    if (cashOutState.holding) {
+      progress = Math.min((currentTimestamp - cashOutState.holdStart) / CASH_OUT_HOLD_DURATION, 1);
+      ctx.fillStyle = '#3cfbff';
+      ctx.fillRect(barX, barY, barWidth * progress, barHeight);
+      ctx.fillStyle = '#ff3cac';
+      ctx.font = '8px "Press Start 2P"';
+      ctx.fillText('HOLDING...', barX, barY - 2);
+    } else if (cooldownRemaining > 0) {
+      progress = Math.min(cooldownRemaining / CASH_OUT_COOLDOWN, 1);
+      ctx.fillStyle = '#ff3cac';
+      ctx.fillRect(barX, barY, barWidth * progress, barHeight);
+      ctx.fillStyle = '#ff3cac';
+      ctx.font = '8px "Press Start 2P"';
+      ctx.fillText('HIT! RECOVERING', barX, barY - 2);
+    } else {
+      ctx.fillStyle = '#3cfbff';
+      ctx.fillRect(barX, barY, barWidth, barHeight);
+      ctx.font = '8px "Press Start 2P"';
+      ctx.fillText('READY', barX, barY - 2);
+    }
+
+    ctx.strokeStyle = 'rgba(60, 251, 255, 0.8)';
+    ctx.strokeRect(barX, barY, barWidth, barHeight);
+  }
+  drawMiniMap();
+  ctx.restore();
+}
+
+function drawMiniMap() {
+  const width = 220;
+  const height = 160;
+  const padding = 24;
+  const x = canvas.width - width - padding;
+  const y = padding;
+  const innerPadding = 12;
+
+  ctx.save();
+  ctx.fillStyle = 'rgba(12, 6, 23, 0.7)';
+  ctx.fillRect(x, y, width, height);
+  ctx.strokeStyle = 'rgba(60, 251, 255, 0.45)';
+  ctx.strokeRect(x, y, width, height);
+
+  const innerWidth = width - innerPadding * 2;
+  const innerHeight = height - innerPadding * 2;
+  const scale = Math.min(innerWidth / world.width, innerHeight / world.height);
+  const offsetX = x + innerPadding + (innerWidth - world.width * scale) / 2;
+  const offsetY = y + innerPadding + (innerHeight - world.height * scale) / 2;
+
+  ctx.fillStyle = 'rgba(6, 3, 12, 0.95)';
+  ctx.fillRect(offsetX, offsetY, world.width * scale, world.height * scale);
+
+  const barrierScaled = world.barrierThickness * scale;
+  ctx.fillStyle = 'rgba(255, 95, 0, 0.28)';
+  ctx.fillRect(offsetX, offsetY, world.width * scale, barrierScaled);
+  ctx.fillRect(offsetX, offsetY + world.height * scale - barrierScaled, world.width * scale, barrierScaled);
+  ctx.fillRect(offsetX, offsetY, barrierScaled, world.height * scale);
+  ctx.fillRect(offsetX + world.width * scale - barrierScaled, offsetY, barrierScaled, world.height * scale);
+
+  const safeX = offsetX + barrierScaled;
+  const safeY = offsetY + barrierScaled;
+  const safeWidth = (world.width - world.barrierThickness * 2) * scale;
+  const safeHeight = (world.height - world.barrierThickness * 2) * scale;
+  ctx.strokeStyle = 'rgba(255, 168, 0, 0.6)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(safeX, safeY, safeWidth, safeHeight);
+
+  bots.forEach((bot) => {
+    ctx.fillStyle = bot.tint;
+    ctx.fillRect(offsetX + (bot.x + bot.width / 2) * scale - 3, offsetY + (bot.y + bot.height / 2) * scale - 3, 6, 6);
+  });
+
+  ctx.fillStyle = '#3cfbff';
+  ctx.beginPath();
+  ctx.arc(offsetX + player.x * scale, offsetY + player.y * scale, 5, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(60, 251, 255, 0.8)';
+  ctx.stroke();
+
+  const viewportX = offsetX + camera.x * scale;
+  const viewportY = offsetY + camera.y * scale;
+  const viewportWidth = Math.min(canvas.width, world.width) * scale;
+  const viewportHeight = Math.min(canvas.height, world.height) * scale;
+  ctx.strokeStyle = 'rgba(245, 255, 92, 0.6)';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(viewportX, viewportY, viewportWidth, viewportHeight);
+
   ctx.restore();
 }
 
@@ -406,24 +781,36 @@ function showOverlay(title, message, { showList = false } = {}) {
     : 'Hit the insert button to rejoin the arena.';
 }
 
-function update(delta) {
-  if (!state.active) return;
-  handleMovement(delta);
-  handleMouseStride(delta);
-  if (shooting) {
-    shoot();
+function update(delta, timestamp) {
+  updateCashOut(timestamp);
+  if (state.active) {
+    handleMovement(delta, timestamp);
+    handleMouseStride(delta, timestamp);
+    if (shooting) {
+      shoot();
+    }
+    handleBotShooting(timestamp);
+    updateBullets(delta);
+    updateBotBullets(delta, timestamp);
+    updateParticles(delta);
+    checkWinState();
+  } else {
+    updateParticles(delta);
   }
-  updateBullets(delta);
-  updateParticles(delta);
-  checkWinState();
+  updateCamera(delta);
 }
 
 function draw() {
   drawBackground();
+  ctx.save();
+  ctx.translate(-camera.x, -camera.y);
+  drawBarrier();
   drawBots();
   drawPlayer();
   drawParticles();
   bullets.forEach((bullet) => bullet.draw());
+  botBullets.forEach((bullet) => bullet.draw());
+  ctx.restore();
   drawUI();
 }
 
@@ -431,7 +818,8 @@ let lastTimestamp = 0;
 function loop(timestamp) {
   const delta = (timestamp - lastTimestamp) / (1000 / 60);
   lastTimestamp = timestamp;
-  update(delta);
+  currentTimestamp = timestamp;
+  update(delta, timestamp);
   draw();
   requestAnimationFrame(loop);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -27,13 +27,14 @@
         <h1>Skill Gamble Arena</h1>
         <p>
           Drop $1 to spawn and battle rival mercenaries for the cash pot. Survive the
-          arena and cash out your winnings. For this prototype, you're matched against
-          static bots &mdash; land your shots to win!
+          arena and cash out your winnings. For this prototype, expect turret-like bots
+          that fire bursts every few seconds &mdash; stay mobile and land your shots to win!
         </p>
         <ul>
           <li>Move with <strong>WASD</strong>, <strong>arrow keys</strong>, or hold <strong>right mouse</strong> to stride.</li>
           <li>Aim with your mouse cursor.</li>
           <li>Left click to fire neon pulses.</li>
+          <li>Hold <strong>G</strong> for three seconds to cash out, but taking damage interrupts the extraction.</li>
         </ul>
         <p class="hint">Press the button above to insert $1 and enter the arena.</p>
       </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -114,11 +114,16 @@ canvas {
   justify-content: center;
   backdrop-filter: blur(2px);
   transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .overlay.hidden {
   opacity: 0;
   pointer-events: none;
+}
+
+.overlay .card {
+  pointer-events: auto;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- guard bot bullet updates against undefined entries when the array is cleared mid-iteration
- exit the bot bullet loop once the player is defeated so the game no longer throws runtime errors

## Testing
- browser_container.run_playwright_script (hold spawn for 60s to confirm no page errors)

------
https://chatgpt.com/codex/tasks/task_e_68d87dcf12208326a92203536a373f6c